### PR TITLE
ปรับโครงสร้างการอัปโหลดไฟล์ด้วย service

### DIFF
--- a/main/services/file_service.py
+++ b/main/services/file_service.py
@@ -1,0 +1,42 @@
+from typing import List, Dict
+from django.db import transaction
+from django.core.files.uploadedfile import UploadedFile as DjangoUploadedFile
+from main.models import UploadedFile
+
+
+class FileService:
+    """จัดการอัปโหลดและลบไฟล์แบบแยกชั้น service"""
+
+    allowed_extensions = [".csv", ".xls", ".xlsx"]
+
+    def upload_files(self, files: List[DjangoUploadedFile]) -> List[Dict]:
+        uploaded_files: List[Dict] = []
+        with transaction.atomic():
+            for file in files:
+                if not self._is_allowed(file.name):
+                    raise ValueError(
+                        f"ไฟล์ {file.name} ไม่ใช่ไฟล์ CSV หรือ Excel ที่รองรับ"
+                    )
+                uploaded_file = UploadedFile.objects.create(name=file.name, file=file)
+                uploaded_files.append(
+                    {
+                        "id": uploaded_file.id,
+                        "name": uploaded_file.name,
+                        "timestamp": uploaded_file.uploaded_at.isoformat(),
+                    }
+                )
+        return uploaded_files
+
+    def delete_file(self, file_id: int) -> None:
+        file = UploadedFile.objects.get(id=file_id)
+        file.file.delete()
+        file.delete()
+
+    def list_files(self) -> List[Dict]:
+        return list(UploadedFile.objects.values("id", "name", "uploaded_at"))
+
+    def all(self):
+        return UploadedFile.objects.all()
+
+    def _is_allowed(self, filename: str) -> bool:
+        return any(filename.endswith(ext) for ext in self.allowed_extensions)

--- a/main/test/services/test_file_service.py
+++ b/main/test/services/test_file_service.py
@@ -1,0 +1,20 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from main.services.file_service import FileService
+from main.models import UploadedFile
+
+
+@pytest.mark.django_db
+def test_upload_files_success():
+    service = FileService()
+    file = SimpleUploadedFile('test.csv', b'a,b\n1,2')
+    result = service.upload_files([file])
+    assert len(result) == 1
+    assert UploadedFile.objects.count() == 1
+
+
+def test_upload_files_invalid_extension():
+    service = FileService()
+    bad_file = SimpleUploadedFile('test.txt', b'data')
+    with pytest.raises(ValueError):
+        service.upload_files([bad_file])

--- a/main/views/views.py
+++ b/main/views/views.py
@@ -2,87 +2,52 @@ from django.shortcuts import render
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.core.files.storage import default_storage
 from django.views.decorators.http import require_POST
+from main.services.file_service import FileService
 from main.models import UploadedFile
-import json
-import os
-import mimetypes
-import pandas as pd
 from . import constants
+
+file_service = FileService()
+
 
 @login_required
 @ensure_csrf_cookie
 def index(request):
-    files = UploadedFile.objects.all()
+    files = file_service.all()
     context = {
         'files': files,
         'analysis_actions': constants.ANALYSIS_ACTIONS.values(),
     }
     return render(request, 'main/index.html', context)
 
+
 def upload_file(request):
-    if request.method == 'POST':
-        files = request.FILES.getlist('files')
-        print("ไฟล์ที่รับมา:", request.FILES)
-        uploaded_files = []
-        # files_count = UploadedFile.objects.count()
-        allowed_extensions = ['.csv', '.xls', '.xlsx']
-        
-        try:
-            for file in files:
-                try:
-                    if not any(file.name.endswith(ext) for ext in allowed_extensions):
-                        return JsonResponse({
-                            'success': False,
-                            'error': f'ไฟล์ {file.name} ไม่ใช่ไฟล์ CSV หรือ Excel ที่รองรับ'
-                        })
-                    uploaded_file = UploadedFile.objects.create(
-                        name=file.name,
-                        file=file
-                    )
-                    uploaded_files.append({
-                        'id': uploaded_file.id,
-                        'name': uploaded_file.name,
-                        'timestamp': uploaded_file.uploaded_at.isoformat(),
-                    })
-                except Exception as e:
-                    return JsonResponse({
-                        'success': False,
-                        'error': f'ไม่สามารถอัปโหลดไฟล์ {file.name} ได้: {str(e)}'
-                    })
-            
-            # Get all files after upload for immediate display
-            all_files = list(UploadedFile.objects.values('id', 'name', 'uploaded_at'))
-            return JsonResponse({
-                'success': True, 
-                'files': uploaded_files,
-                'allFiles': all_files,
-                'count': UploadedFile.objects.count()
-            })
-        except Exception as e:
-            return JsonResponse({
-                'success': False,
-                'error': f'เกิดข้อผิดพลาดในการอัปโหลด: {str(e)}'
-            })
-    
-    return JsonResponse({
-        'success': False,
-        'error': 'Invalid request method'
-    })
+    if request.method != 'POST':
+        return JsonResponse({'success': False, 'error': 'Invalid request method'})
+
+    files = request.FILES.getlist('files')
+    try:
+        uploaded_files = file_service.upload_files(files)
+        all_files = file_service.list_files()
+        return JsonResponse({
+            'success': True,
+            'files': uploaded_files,
+            'allFiles': all_files,
+            'count': len(all_files)
+        })
+    except ValueError as e:
+        return JsonResponse({'success': False, 'error': str(e)})
+    except Exception as e:
+        return JsonResponse({'success': False, 'error': f'เกิดข้อผิดพลาดในการอัปโหลด: {str(e)}'})
+
 
 @require_POST
 def delete_uploaded_file(request):
     file_id = request.POST.get('file_id')
-
     if not file_id:
         return JsonResponse({'success': False, 'message': 'Missing file ID'})
-
     try:
-        file = UploadedFile.objects.get(id=file_id)
-        file.file.delete()  # ลบไฟล์จริงจาก disk ด้วย
-        file.delete()       # ลบ record ออกจาก database
+        file_service.delete_file(file_id)
         return JsonResponse({'success': True})
     except UploadedFile.DoesNotExist:
         return JsonResponse({'success': False, 'message': 'File not found'})
-    

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,4 @@ whitenoise
 pandas
 dj_database_url
 pytest
-<<<<<<< HEAD
-dotenv
-=======
-dotenv
->>>>>>> c86bc2ea57817d9378f6b316121221c4c9025907
+python-dotenv

--- a/tests/test_www.py
+++ b/tests/test_www.py
@@ -1,5 +1,7 @@
 import pytest
 from main.TopCenter.controllers.top_clinic_controller import find_top_clinics_summary
 
+
 def test_output():
-    assert isinstance(find_top_clinics_summary, list)
+    result = find_top_clinics_summary()
+    assert isinstance(result, list)


### PR DESCRIPTION
## Summary
- แยกชั้น FileService สำหรับอัปโหลด/ลบไฟล์และให้ view เรียกใช้งาน
- แก้ requirements.txt และปรับปรุงการทดสอบ

## Testing
- `PYTHONPATH=. pytest` (ล้มเหลว: No module named 'pandas', No module named 'django')

------
https://chatgpt.com/codex/tasks/task_e_68979b38731083239990512afed253ec