### PR TITLE
ปรับโครงสร้าง TypeEmailService และเพิ่มการทดสอบ

### DIFF
--- a/main/services/type_email_service.py
+++ b/main/services/type_email_service.py
@@ -1,0 +1,86 @@
+from django.http import JsonResponse
+from datetime import datetime, timedelta
+
+from main.views.inquiry import cal_inquiry
+from main.views.appointment import find_appointment_summary
+from main.views.feedback_package import FPtotal
+from main.views.compare.result_compare import Resultcompare
+
+
+class TypeEmailService:
+    @classmethod
+    def cal_all_type_email(cls, date):
+        try:
+            start = date.get('startDate')
+            end = date.get('endDate')
+            raw, summary = cal_inquiry(start, end)
+            summaryFeed = FPtotal(date)
+            summaryAppointment = find_appointment_summary(date)
+
+            index1 = summary[0].get('General Inquiry')
+            index2 = summary[0].get('Estimated Cost')
+            index3 = summary[0].get('Other')
+            index4 = summary[0].get('Contact Doctor')
+            index5 = summaryFeed[0].get('Packages')
+            index6 = summaryFeed[0].get('Feedback')
+            index7 = summaryAppointment[0].get('Appointment')
+            index8 = summaryAppointment[0].get('Appointment Recommended')
+
+            json_temp = {
+                'Type Email': 'Total',
+                'General Inquiry': index1,
+                'Estimated Cost': index2,
+                'Other': index3,
+                'Contact Doctor': index4,
+                'Package Inquiry': index5,
+                'Feedback & Suggestion': index6,
+                'Appointment': index7,
+                'Appointment Recommended': index8,
+            }
+            return json_temp
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)
+
+    @classmethod
+    def map_spit_date(cls, date):
+        start_date = datetime.strptime(date['startDate'], "%Y-%m-%d")
+        end_date = datetime.strptime(date['endDate'], "%Y-%m-%d")
+
+        current = start_date
+        list_data_by_date = []
+        while current <= end_date:
+            date_list = {
+                'startDate': current.strftime("%Y-%m-%d"),
+                'endDate': current.strftime("%Y-%m-%d")
+            }
+            data_per_day = cls.cal_all_type_email(date_list)
+            new_item = {'Date': date_list['startDate']}
+            new_item.update(data_per_day)
+            list_data_by_date.append(new_item)
+            current += timedelta(days=1)
+
+        return list_data_by_date
+
+    @classmethod
+    def find_all_type_email(cls, date_param):
+        try:
+            if len(date_param) <= 1:
+                table = cls.cal_all_type_email(date_param[0])
+                line = cls.map_spit_date(date_param[0])
+                return {
+                    'table': [table],
+                    'chart1': [table],
+                    'chart2': line,
+                }
+            else:
+                data1 = cls.cal_all_type_email(date_param[0])
+                data2 = cls.cal_all_type_email(date_param[1])
+                line = cls.map_spit_date(date_param[0])
+                table = Resultcompare([data1], [data2], date_param)
+                return {
+                    'table': table,
+                    'chart1': table,
+                    'chart2': line,
+                }
+        except Exception as e:
+            print('From find_all_type_email', e)

--- a/main/views/Total_Email_of_Language.py
+++ b/main/views/Total_Email_of_Language.py
@@ -5,7 +5,7 @@ from .feedback_package import cal_FeedbackAndPackage
 from .appointment import find_appointment_from_csv_folder
 from .compare.result_compare import Resultcompare
 from .percentage.cal_percentage import find_percentage, cal_percent
-from .Type_email import cal_all_type_email
+from main.services.type_email_service import TypeEmailService
 import json
 
 def cal_TotalMonth(date, Web_Commerce):
@@ -180,7 +180,7 @@ def find_TotalMonth(date, web):
         if len(date) <= 1:
             print("it 1")
             total, plot_data, transposed = cal_TotalMonth(date[0], web[0])
-            type_email = cal_all_type_email(date[0])
+            type_email = TypeEmailService.cal_all_type_email(date[0])
             # return [total, plot_data, type_email[0]]
             return {
                 "table": total,
@@ -191,7 +191,7 @@ def find_TotalMonth(date, web):
             print("it 2")
             totalset1, plot_data, transposed = cal_TotalMonth(date[0], web[0])
             totalset2, plot_data, transposed = cal_TotalMonth(date[1], web[1])
-            type_email = cal_all_type_email(date[0])
+            type_email = TypeEmailService.cal_all_type_email(date[0])
             compare = Resultcompare(totalset1, totalset2, date) 
             return {
                 "table": compare,

--- a/main/views/Total_Email_of_Language/services/total_services.py
+++ b/main/views/Total_Email_of_Language/services/total_services.py
@@ -1,5 +1,5 @@
 from .Total_Email_of_Language import cal_TotalMonth
-from main.views.Type_email import cal_all_type_email
+from main.services.type_email_service import TypeEmailService
 from main.views.compare.result_compare import Resultcompare
 from ..models.chart1 import Grand_Total_By_Language 
 from ..models.chart3 import Total_Email_Type_By_Language
@@ -18,7 +18,7 @@ def find_TotalMonth(date, web):
             summary, plot_data, transposed = cal_TotalMonth(date[0], web[0])
             data_json['table'] = summary
             data_json['chart1'] = Grand_Total_By_Language(summary)
-            data_json['chart2'] = [cal_all_type_email(date[0])]
+            data_json['chart2'] = [TypeEmailService.cal_all_type_email(date[0])]
             data_json['chart3'] = Total_Email_Type_By_Language(summary)
             data_json['chart4'] = inquiry_by_lang(summary)
             data_json['chart5'] = appointment_by_lang(summary)
@@ -31,7 +31,7 @@ def find_TotalMonth(date, web):
             print("it 2")
             totalset1, plot_data, transposed = cal_TotalMonth(date[0], web[0])
             totalset2, plot_data, transposed = cal_TotalMonth(date[1], web[1])
-            type_email = cal_all_type_email(date[0])
+            type_email = TypeEmailService.cal_all_type_email(date[0])
             compare = Resultcompare(totalset1, totalset2, date) 
             return {
                 "table": compare,

--- a/main/views/Type_email.py
+++ b/main/views/Type_email.py
@@ -1,119 +1,15 @@
 from django.http import JsonResponse
-from collections import defaultdict
-from datetime import datetime, timedelta
+import json
 
-from .inquiry import cal_inquiry
-from .appointment import find_appointment_summary
-from .feedback_package import FPtotal
-from .compare.result_compare import Resultcompare
+from main.services.type_email_service import TypeEmailService
 
 
-json_temp = [{
-    'Date',
-    'General Inquiry',                 
-    'Estimated Cost',
-    'Other',
-    'Contact My Doctor at Bangkok Hospital Pattaya',
-    'Package Inquiry',
-    'Feedback & Suggestion',
-    'Appointment',
-    'Appointment Recommended',
-    'Web Commerce',
-}]
-
-def map_parts(s):
-    parts = list(map(int, s.strip().split()))
-
-    if len(parts) == 1:
-        a = parts[0]
-        return a
-    elif len(parts) >= 2:
-        a, b = parts[0], parts[1]
-        return a, b
-    else:
-        print("ไม่มีตัวเลขเลย")
-
-def cal_all_type_email(date):
+def find_all_type_email(request):
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Only POST method is allowed'}, status=405)
     try:
-        # print(date)
-        start = date.get('startDate')
-        end = date.get('endDate')
-        raw, summary = cal_inquiry(start, end)        # dict ภาษา-> dict category-> count
-        summaryFeed = FPtotal(date)
-        summaryAppointment = find_appointment_summary(date)  # dict ภาษา-> count fields
-        # print("feed :",summaryAppointment)
-
-        index1 = summary[0].get('General Inquiry')
-        index2 = summary[0].get('Estimated Cost')
-        index3 = summary[0].get('Other')
-        index4 = summary[0].get('Contact Doctor')
-        index5 = summaryFeed[0].get('Packages')
-        index6 = summaryFeed[0].get('Feedback')
-        index7 = summaryAppointment[0].get('Appointment')
-        index8 = summaryAppointment[0].get('Appointment Recommended')
-
-        json_temp = {
-                    'Type Email'                         : 'Total',
-                    'General Inquiry'                    : index1,
-                    'Estimated Cost'                     : index2,
-                    'Other'                              : index3,
-                    'Contact Doctor': index4,
-                    'Package Inquiry'                    : index5,
-                    'Feedback & Suggestion'              : index6,
-                    'Appointment'                        : index7,
-                    'Appointment Recommended'            : index8,
-                };
-
-        
-
-        return json_temp
-        
+        date_param = json.loads(request.body)
+        data = TypeEmailService.find_all_type_email(date_param)
+        return JsonResponse(data, safe=False)
     except Exception as e:
-        return JsonResponse({"error": str(e)}, status=500)
-    
-def map_spit_date(date):
-    start_date = datetime.strptime(date['startDate'], "%Y-%m-%d")
-    end_date = datetime.strptime(date['endDate'], "%Y-%m-%d")
-
-    current = start_date
-    list_data_by_date = [];
-    new_item = {}
-    while current <= end_date:
-        date_list = {
-            'startDate': current.strftime("%Y-%m-%d"),
-            'endDate': current.strftime("%Y-%m-%d")
-        }
-        data_per_day = cal_all_type_email(date_list)
-        new_item = {'Date': date_list['startDate']}
-        new_item.update(data_per_day)
-        list_data_by_date.append(new_item)
-        current += timedelta(days=1)
-    
-    return list_data_by_date
-
-def find_all_type_email(date_param):
-    try:
-        if len(date_param) <= 1:
-            print('it 1 !!')
-            table = cal_all_type_email(date_param[0])
-            line = map_spit_date(date_param[0])
-            # print(line)
-            return {
-               "table": [table],
-               "chart1": [table],
-               "chart2": line
-            }
-        else :
-            print('it 2 !!')
-            data1 = cal_all_type_email(date_param[0])
-            data2 = cal_all_type_email(date_param[1])
-            line = map_spit_date(date_param[0])
-            table = Resultcompare([data1], [data2], date_param)
-            return {
-               "table": table,
-               "chart1": table,
-               "chart2": line
-            }
-
-    except Exception as e:
-        print('From find_all_type_email', e)
+        return JsonResponse({'error': str(e)}, status=500)

--- a/main/views/constants.py
+++ b/main/views/constants.py
@@ -1,7 +1,6 @@
 from .inquiry import find_inquiry, get_total_languages_summary
 from .appointment import find_appointment
 from .feedback_package import find_FeedbackAndPackage, FPtotal
-from .Type_email import find_all_type_email
 from main.views.TopCenter.controllers.top_clinic_controller import find_top_clinics_summary
 from .top_center import find_top_clinics_summary_main
 from main.views.Total_Email_of_Language.services.total_services import find_TotalMonth

--- a/tests/services/test_type_email_service.py
+++ b/tests/services/test_type_email_service.py
@@ -1,0 +1,61 @@
+import pytest
+
+from main.services.type_email_service import TypeEmailService
+
+
+def test_cal_all_type_email(monkeypatch):
+    def fake_cal_inquiry(start, end):
+        return None, [{'General Inquiry': 1, 'Estimated Cost': 2, 'Other': 3, 'Contact Doctor': 4}]
+
+    def fake_FPtotal(date):
+        return [{'Packages': 5, 'Feedback': 6}]
+
+    def fake_find_appointment_summary(date):
+        return [{'Appointment': 7, 'Appointment Recommended': 8}]
+
+    monkeypatch.setattr('main.services.type_email_service.cal_inquiry', fake_cal_inquiry)
+    monkeypatch.setattr('main.services.type_email_service.FPtotal', fake_FPtotal)
+    monkeypatch.setattr('main.services.type_email_service.find_appointment_summary', fake_find_appointment_summary)
+
+    result = TypeEmailService.cal_all_type_email({'startDate': '2024-01-01', 'endDate': '2024-01-01'})
+
+    assert result['General Inquiry'] == 1
+    assert result['Estimated Cost'] == 2
+    assert result['Other'] == 3
+    assert result['Contact Doctor'] == 4
+    assert result['Package Inquiry'] == 5
+    assert result['Feedback & Suggestion'] == 6
+    assert result['Appointment'] == 7
+    assert result['Appointment Recommended'] == 8
+
+
+def test_find_all_type_email_single_range(monkeypatch):
+    monkeypatch.setattr(TypeEmailService, 'cal_all_type_email', classmethod(lambda cls, d: {'value': 1}))
+    monkeypatch.setattr(TypeEmailService, 'map_spit_date', classmethod(lambda cls, d: [{'Date': d['startDate'], 'value': 1}]))
+
+    data = TypeEmailService.find_all_type_email([
+        {'startDate': '2024-01-01', 'endDate': '2024-01-01'}
+    ])
+
+    assert data['table'] == [{'value': 1}]
+    assert data['chart1'] == [{'value': 1}]
+    assert data['chart2'] == [{'Date': '2024-01-01', 'value': 1}]
+
+
+def test_find_all_type_email_two_ranges(monkeypatch):
+    monkeypatch.setattr(TypeEmailService, 'cal_all_type_email', classmethod(lambda cls, d: {'value': d['startDate']}))
+    monkeypatch.setattr(TypeEmailService, 'map_spit_date', classmethod(lambda cls, d: [{'Date': d['startDate']}]))
+
+    def fake_Resultcompare(d1, d2, dates):
+        return [{'compare': True}]
+
+    monkeypatch.setattr('main.services.type_email_service.Resultcompare', fake_Resultcompare)
+
+    data = TypeEmailService.find_all_type_email([
+        {'startDate': '2024-01-01', 'endDate': '2024-01-01'},
+        {'startDate': '2024-02-01', 'endDate': '2024-02-01'}
+    ])
+
+    assert data['table'] == [{'compare': True}]
+    assert data['chart1'] == [{'compare': True}]
+    assert data['chart2'] == [{'Date': '2024-01-01'}]


### PR DESCRIPTION
## Summary
- ย้ายตรรกะคำนวณประเภทอีเมลไปยัง `TypeEmailService`
- ปรับ view ให้เรียกใช้ service แทนโค้ดภายในไฟล์
- เพิ่มชุดทดสอบสำหรับ `TypeEmailService`

## Testing
- `pytest` *(ล้มเหลว: ModuleNotFoundError และขาด dependency)*
- `pip install pandas` *(ล้มเหลว: Could not find a version that satisfies the requirement)*
- `pip install django` *(ล้มเหลว: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68979ea20eb08323b9f8ef7e4ae2a5ce