### PR TITLE
fix: use services and support csv date formats

### DIFF
--- a/main/services/appointment_service.py
+++ b/main/services/appointment_service.py
@@ -80,14 +80,20 @@ class AppointmentService:
         result = []
         start = datetime.strptime(start_date, "%Y-%m-%d")
         end = datetime.strptime(end_date, "%Y-%m-%d")
+        date_formats = ["%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y", "%Y/%m/%d"]
         for item in filtered_list:
-            entry_str = item.get(date_key, "")
-            try:
-                entry = datetime.strptime(entry_str.split(" ")[0], "%d/%m/%Y")
-                if start <= entry <= end:
-                    result.append(item)
-            except ValueError:
+            entry_str = item.get(date_key, "").split(" ")[0]
+            entry = None
+            for fmt in date_formats:
+                try:
+                    entry = datetime.strptime(entry_str, fmt)
+                    break
+                except ValueError:
+                    continue
+            if not entry:
                 continue
+            if start <= entry <= end:
+                result.append(item)
         return result
 
     def load_date(self, datetimes):

--- a/main/views/Total_Email_of_Language/services/Total_Email_of_Language.py
+++ b/main/views/Total_Email_of_Language/services/Total_Email_of_Language.py
@@ -1,11 +1,7 @@
-from django.http import JsonResponse
-from main.models import UploadedFile
-from main.views.inquiry import get_total_languages_summary
 from main.services.inquiry_service import InquiryService
-from main.views.feedback_package import cal_FeedbackAndPackage
-from main.views.appointment import find_appointment_from_csv_folder
+from main.services.feedback_package_service import FeedbackPackageService
+from main.services.appointment_service import AppointmentService
 from main.views.percentage.cal_percentage import find_percentage, cal_percent
-import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -16,10 +12,13 @@ def cal_TotalMonth(date, Web_Commerce):
         dateset2 = date.get('endDate')
 
         # print(dateset1, dateset2)
-        # total_inquiry = get_total_languages_summary(date)
         total_inquiry, chart = InquiryService.cal_inquiry(dateset1, dateset2)
-        total_feedback_package = cal_FeedbackAndPackage(date)
-        total_appointment = find_appointment_from_csv_folder((dateset1, dateset2))
+
+        feedback_service = FeedbackPackageService()
+        total_feedback_package = feedback_service.cal_FeedbackAndPackage(date)
+
+        appointment_service = AppointmentService()
+        total_appointment = appointment_service.find_appointment_from_csv_folder((dateset1, dateset2))
 
         # flatten ถ้า list ซ้อน
         if isinstance(total_feedback_package, list) and isinstance(total_feedback_package[0], dict) is False:


### PR DESCRIPTION
## Summary
- use service classes in `cal_TotalMonth`
- support multiple date formats when filtering appointment CSVs

## Testing
- `pytest tests/services/test_file_service.py -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `pytest tests/topcenter/test_top_clinic_controller.py -q` *(fails: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6898d47543e483238d36f27d010a7c6d